### PR TITLE
updated dockerfile

### DIFF
--- a/7.0-dev/Dockerfile
+++ b/7.0-dev/Dockerfile
@@ -163,4 +163,5 @@ RUN set -xe && \
     cd /opt && curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar xz && \
     ln -s /opt/node-v${NODE_VERSION}-linux-x64/bin/node /usr/bin/node && \
     ln -s /opt/node-v${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm && \
-    npm install --prefix=/usr/local -g npm-cache bower
+    npm install --prefix=/usr/local -g npm-cache bower && \
+    npm rebuild node-sass


### PR DESCRIPTION
maba:webpack:compile klapt er uit doordat er een verkeerde versie van de 'GLIBCXX_' lib is geinstalleerd. npm resolved de versie niet goed door het verschil in global en local modules.

https://github.com/sass/node-sass/issues/1162