### PR TITLE
CASH-1938 Compile librdkafka version 1.2.1

### DIFF
--- a/7.2-dev/Dockerfile
+++ b/7.2-dev/Dockerfile
@@ -15,8 +15,6 @@ RUN set -xe && \
         libxml2-dev \
         # ext-imap
         libc-client2007e \
-        # pecl-rdkafka
-        librdkafka1 \
     " && \
     buildDeps=" \
         git \
@@ -51,8 +49,6 @@ RUN set -xe && \
         libmemcached-dev zlib1g-dev \
         # pecl-imagick \
         libmagickwand-dev \
-        # pecl-rdkafka \
-        librdkafka-dev \
     " && \
 
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install $buildDeps $requiredDeps nullmailer --no-install-recommends && \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -15,8 +15,6 @@ RUN set -xe && \
         libxml2-dev \
         # ext-imap
         libc-client2007e \
-        # pecl-rdkafka
-        librdkafka1 \
     " && \
     buildDeps=" \
         git \
@@ -51,8 +49,6 @@ RUN set -xe && \
         libmemcached-dev zlib1g-dev \
         # pecl-imagick \
         libmagickwand-dev \
-        # pecl-rdkafka \
-        librdkafka-dev \
     " && \
 
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install $buildDeps $requiredDeps nullmailer --no-install-recommends && \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -17,27 +17,33 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib-dev \
     # ext-pdo_pgsql
     postgresql-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
     tidyhtml-dev \
     # ext-zip
     libzip-dev \
+    # librdkafka
+    openssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "%%PHP_VERSION%%" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug %%XDEBUG_VERSION%% \
     # Configure extensions

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -4,7 +4,7 @@ ARG ICU4C_SRC="%%LIBICU%%"
 
 COPY docker-php-ext-get /usr/local/bin/docker-php-ext-get
 
-    # Install dependencies
+# Install dependencies
 RUN chmod u+x /usr/local/bin/docker-php-ext-get \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${PHPIZE_DEPS} \
@@ -20,8 +20,6 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib1g-dev \
     # ext-pdo_pgsql
     libpq-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
@@ -30,19 +28,27 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libzip-dev \
     # libfcgi-bin is used for cgi-fcgi healthcheck in k8s containers
     libfcgi-bin \
+    # librdkafka
+    libssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "%%PHP_VERSION%%" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug %%XDEBUG_VERSION%% \
     # Configure extensions
@@ -99,7 +105,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     | cut -d: -f1 \
     | sort -u \
     | xargs -r apt-mark manual \
- && apt-mark manual librdkafka1 libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
+ && apt-mark manual libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
     # Remove build dependencies
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     # Disable all extensions by default

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.2-alpine/Dockerfile
+++ b/fpm-7.2-alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.2-alpine/Dockerfile
+++ b/fpm-7.2-alpine/Dockerfile
@@ -17,27 +17,33 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib-dev \
     # ext-pdo_pgsql
     postgresql-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
     tidyhtml-dev \
     # ext-zip
     libzip-dev \
+    # librdkafka
+    openssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "7.2" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug 3.0.2 \
     # Configure extensions

--- a/fpm-7.2-alpine/Dockerfile
+++ b/fpm-7.2-alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.2/Dockerfile
+++ b/fpm-7.2/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.2/Dockerfile
+++ b/fpm-7.2/Dockerfile
@@ -4,7 +4,7 @@ ARG ICU4C_SRC="https://github.com/unicode-org/icu/releases/download/release-64-2
 
 COPY docker-php-ext-get /usr/local/bin/docker-php-ext-get
 
-    # Install dependencies
+# Install dependencies
 RUN chmod u+x /usr/local/bin/docker-php-ext-get \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${PHPIZE_DEPS} \
@@ -20,8 +20,6 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib1g-dev \
     # ext-pdo_pgsql
     libpq-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
@@ -30,19 +28,27 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libzip-dev \
     # libfcgi-bin is used for cgi-fcgi healthcheck in k8s containers
     libfcgi-bin \
+    # librdkafka
+    libssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "7.2" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug 3.0.2 \
     # Configure extensions
@@ -99,7 +105,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     | cut -d: -f1 \
     | sort -u \
     | xargs -r apt-mark manual \
- && apt-mark manual librdkafka1 libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
+ && apt-mark manual libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
     # Remove build dependencies
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     # Disable all extensions by default

--- a/fpm-7.2/Dockerfile
+++ b/fpm-7.2/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.3-alpine/Dockerfile
+++ b/fpm-7.3-alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.3-alpine/Dockerfile
+++ b/fpm-7.3-alpine/Dockerfile
@@ -17,27 +17,33 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib-dev \
     # ext-pdo_pgsql
     postgresql-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
     tidyhtml-dev \
     # ext-zip
     libzip-dev \
+    # librdkafka
+    openssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "7.3" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug 3.0.2 \
     # Configure extensions

--- a/fpm-7.3-alpine/Dockerfile
+++ b/fpm-7.3-alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.3/Dockerfile
+++ b/fpm-7.3/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.3/Dockerfile
+++ b/fpm-7.3/Dockerfile
@@ -4,7 +4,7 @@ ARG ICU4C_SRC="https://github.com/unicode-org/icu/releases/download/release-64-2
 
 COPY docker-php-ext-get /usr/local/bin/docker-php-ext-get
 
-    # Install dependencies
+# Install dependencies
 RUN chmod u+x /usr/local/bin/docker-php-ext-get \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${PHPIZE_DEPS} \
@@ -20,8 +20,6 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib1g-dev \
     # ext-pdo_pgsql
     libpq-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
@@ -30,19 +28,27 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libzip-dev \
     # libfcgi-bin is used for cgi-fcgi healthcheck in k8s containers
     libfcgi-bin \
+    # librdkafka
+    libssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "7.3" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug 3.0.2 \
     # Configure extensions
@@ -99,7 +105,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     | cut -d: -f1 \
     | sort -u \
     | xargs -r apt-mark manual \
- && apt-mark manual librdkafka1 libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
+ && apt-mark manual libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
     # Remove build dependencies
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     # Disable all extensions by default

--- a/fpm-7.3/Dockerfile
+++ b/fpm-7.3/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.4-alpine/Dockerfile
+++ b/fpm-7.4-alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.4-alpine/Dockerfile
+++ b/fpm-7.4-alpine/Dockerfile
@@ -17,27 +17,33 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib-dev \
     # ext-pdo_pgsql
     postgresql-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
     tidyhtml-dev \
     # ext-zip
     libzip-dev \
+    # librdkafka
+    openssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "7.4" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug 3.0.2 \
     # Configure extensions

--- a/fpm-7.4-alpine/Dockerfile
+++ b/fpm-7.4-alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.4/Dockerfile
+++ b/fpm-7.4/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions

--- a/fpm-7.4/Dockerfile
+++ b/fpm-7.4/Dockerfile
@@ -4,7 +4,7 @@ ARG ICU4C_SRC="https://github.com/unicode-org/icu/releases/download/release-65-1
 
 COPY docker-php-ext-get /usr/local/bin/docker-php-ext-get
 
-    # Install dependencies
+# Install dependencies
 RUN chmod u+x /usr/local/bin/docker-php-ext-get \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${PHPIZE_DEPS} \
@@ -20,8 +20,6 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libmemcached-dev zlib1g-dev \
     # ext-pdo_pgsql
     libpq-dev \
-    # ext-rdkafka
-    librdkafka-dev \
     # ext-soap
     libxml2-dev \
     # ext-tidy
@@ -30,19 +28,27 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     libzip-dev \
     # libfcgi-bin is used for cgi-fcgi healthcheck in k8s containers
     libfcgi-bin \
+    # librdkafka
+    libssl-dev \
     # Install libicu library
  && curl -L ${ICU4C_SRC} | tar xz -C /tmp \
  && cd /tmp/icu/source \
  && ./runConfigureICU Linux/gcc \
  && make -j$(nproc) install \
  && rm -rf /tmp/icu \
- && cd / \
+    # Add librdkafka library
+ && mkdir -p /tmp/librdkafka \
+ && cd /tmp/librdkafka \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && ./configure && make && make install \
+ && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions
+ && cd / \
  && docker-php-source extract \
  && docker-php-ext-get imagick 3.4.4 \
  && docker-php-ext-get memcached 3.1.5 \
  && if [ "7.4" != "7.0" ]; then docker-php-ext-get pcov 1.0.6;fi \
- && docker-php-ext-get rdkafka 3.1.0 \
+ && docker-php-ext-get rdkafka 5.0.0 \
  && docker-php-ext-get redis 5.1.1 \
  && docker-php-ext-get xdebug 3.0.2 \
     # Configure extensions
@@ -99,7 +105,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     | cut -d: -f1 \
     | sort -u \
     | xargs -r apt-mark manual \
- && apt-mark manual librdkafka1 libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
+ && apt-mark manual libmemcached11 libmemcachedutil2 libc6 binutils libfcgi-bin ca-certificates \
     # Remove build dependencies
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     # Disable all extensions by default

--- a/fpm-7.4/Dockerfile
+++ b/fpm-7.4/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod u+x /usr/local/bin/docker-php-ext-get \
     # Add librdkafka library
  && mkdir -p /tmp/librdkafka \
  && cd /tmp/librdkafka \
- && curl -L https://github.com/edenhill/librdkafka/archive/v1.6.0.tar.gz | tar xz --strip-components=1 \
+ && curl -L https://github.com/edenhill/librdkafka/archive/v1.2.1.tar.gz | tar xz --strip-components=1 \
  && ./configure && make && make install \
  && rm -rf /tmp/librdkafka \
     # pre-fetch pecl extensions


### PR DESCRIPTION
~I used a newer version of the library (1.6.0) than currently runs at TRUE (1.2.1). Do we want to match that version, or are we ok to be a little ahead on that one?~ Edit: changed it to v1.2.1.

Furthermore I also bumped the version of the PHP extension from 3.1.0 to 5.0.0 in order to be compatible with the updated library (which matches the TRUE version).